### PR TITLE
Fix multiple definition of default template arguments

### DIFF
--- a/include/istream
+++ b/include/istream
@@ -340,7 +340,7 @@ namespace std{
 
 	};
 	
-	template <class charT,class traits = char_traits<charT> > class _UCXXEXPORT basic_istream<charT,traits>::sentry {
+	template <class charT,class traits> class _UCXXEXPORT basic_istream<charT,traits>::sentry {
 		bool ok;
 	public:
 		explicit _UCXXEXPORT sentry(basic_istream<charT,traits>& os, bool noskipws = false){

--- a/include/ostream
+++ b/include/ostream
@@ -277,7 +277,7 @@ namespace std {
 #endif
 #endif
 
-	template <class charT,class traits = char_traits<charT> >
+	template <class charT,class traits>
 		class _UCXXEXPORT basic_ostream<charT,traits>::sentry
 	{
 		bool ok;


### PR DESCRIPTION
sentry's definition tries to redefines basic_ostream and basic_istream
default template arguments.

This fixes compilation errors with avr-gcc 6.2.0.
